### PR TITLE
Ensure /dev/random and /dev/urandom exist inside build chroot

### DIFF
--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -147,6 +147,8 @@ mknod -m 0600 "$BOOTSTRAP_MNT"/dev/kmsg c 1 11
 mknod -m 0666 "$BOOTSTRAP_MNT"/dev/null c 1 3
 mknod -m 0666 "$BOOTSTRAP_MNT"/dev/full c 1 7
 mknod -m 0666 "$BOOTSTRAP_MNT"/dev/zero c 1 5
+mknod -m 0666 "$BOOTSTRAP_MNT"/dev/random c 1 8
+mknod -m 0666 "$BOOTSTRAP_MNT"/dev/urandom c 1 9
 
 # Sometimes we hit a bad mirror and yum fails with a timeout message, so
 # let's try three times
@@ -158,7 +160,7 @@ until yum -y --noplugins -c /root/yum.conf \
 			basesystem grub2 kernel dracut e2fsprogs yum \
 			yum-plugin-post-transaction-actions attr patch \
 			dhclient openssh-server selinux-policy-targeted \
-			less vim-minimal policycoreutils-python audit
+			less vim-minimal policycoreutils-python audit nspr
 do
 	RC=$?
 	if [ $I -ge 2 ]; then

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -160,7 +160,7 @@ until yum -y --noplugins -c /root/yum.conf \
 			basesystem grub2 kernel dracut e2fsprogs yum \
 			yum-plugin-post-transaction-actions attr patch \
 			dhclient openssh-server selinux-policy-targeted \
-			less vim-minimal policycoreutils-python audit nspr
+			less vim-minimal policycoreutils-python audit
 do
 	RC=$?
 	if [ $I -ge 2 ]; then


### PR DESCRIPTION
These character devices are required during the build, their absence was causing builds to fail.