### PR TITLE
Do less work in sub-shells where possible

### DIFF
--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -180,8 +180,8 @@ __EOF__
 chmod 0644 "$BOOTSTRAP_MNT"/etc/rpm/macros.local
 
 SCRIPT_CHECKSUM=$(sha256sum "${BASH_SOURCE[0]}" | cut -f1 -d' ')
-IMAGE_CHECKSUM=$(chroot "$BOOTSTRAP_MNT" /bin/sh -c "rpm -qa | LC_ALL=C sort | sha256sum | cut -f1 -d' '")
-DISTRO_RELEASE=$(chroot "$BOOTSTRAP_MNT" /bin/sh -c "rpm -q centos-release | sed -n 's,^centos-release-\([[:digit:].-]\+\)\.el.*,\1,;T;s,-,.,;p'")
+IMAGE_CHECKSUM=$(chroot "$BOOTSTRAP_MNT" /bin/sh -c 'rpm -qa' | LC_ALL=C sort | sha256sum | cut -f1 -d' ')
+DISTRO_RELEASE=$(chroot "$BOOTSTRAP_MNT" /bin/sh -c 'rpm -q centos-release' | sed -n 's,^centos-release-\([[:digit:].-]\+\)\.el.*,\1,;T;s,-,.,;p')
 
 # Compatibility with the previous versions
 if [ -s /root/bootstrap-addon.sh ]; then

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -180,8 +180,8 @@ __EOF__
 chmod 0644 "$BOOTSTRAP_MNT"/etc/rpm/macros.local
 
 SCRIPT_CHECKSUM=$(sha256sum "${BASH_SOURCE[0]}" | cut -f1 -d' ')
-IMAGE_CHECKSUM=$(chroot "$BOOTSTRAP_MNT" /bin/sh -c 'rpm -qa' | LC_ALL=C sort | sha256sum | cut -f1 -d' ')
-DISTRO_RELEASE=$(chroot "$BOOTSTRAP_MNT" /bin/sh -c 'rpm -q centos-release' | sed -n 's,^centos-release-\([[:digit:].-]\+\)\.el.*,\1,;T;s,-,.,;p')
+IMAGE_CHECKSUM=$(chroot "$BOOTSTRAP_MNT" /bin/sh -ec 'rpm -qa' | LC_ALL=C sort | sha256sum | cut -f1 -d' ')
+DISTRO_RELEASE=$(chroot "$BOOTSTRAP_MNT" /bin/sh -ec 'rpm -q centos-release' | sed -n 's,^centos-release-\([[:digit:].-]\+\)\.el.*,\1,;T;s,-,.,;p')
 
 # Compatibility with the previous versions
 if [ -s /root/bootstrap-addon.sh ]; then


### PR DESCRIPTION
This change minimises work done in sub-shells to reduce opportunity for a non-zero exit to be masked.

The result is the script is more likely to abort (as designed) under failure cases.